### PR TITLE
follow super-linter to new location

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -46,7 +46,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v5
+        uses: super-linter/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main


### PR DESCRIPTION
GitHub’s Super-Linter will migrate[^1] from [github/super-linter](https://github.com/github/super-linter) to [super-linter/super-linter](https://github.com/super-linter/super-linter).

[^1]: <q>At some point we will switch to [[super-linter/super-linter](https://github.com/super-linter/super-linter)] only</q> —[@**lindluni**](https://github.com/lindluni), [super-linter/super-linter #4150](https://github.com/super-linter/super-linter/issues/4150#issuecomment-1524103622).